### PR TITLE
Fix: onboarding slider to not be in infinite loop

### DIFF
--- a/src/components/Onboarding.js
+++ b/src/components/Onboarding.js
@@ -17,7 +17,7 @@ class Onboarding extends React.Component {
   render() {
     let settings = {
       dots: true,
-      infinite: true,
+      infinite: false,
       speed: 1000,
       slidesToShow: 1,
       slidesToScroll: 1,


### PR DESCRIPTION
Onboarding slides won't go in infinite loop 